### PR TITLE
[DEV-6105] update sqlalchemy 1.4.42

### DIFF
--- a/docs/database_queries.md
+++ b/docs/database_queries.md
@@ -107,3 +107,20 @@ Note that query arguments should follow the `:query_arg` style.
 
 [sqlalchemy-core]: https://docs.sqlalchemy.org/en/latest/core/
 [sqlalchemy-core-tutorial]: https://docs.sqlalchemy.org/en/latest/core/tutorial.html
+
+## Query result
+
+To keep in line with [SQLAlchemy 1.4 changes][sqlalchemy-mapping-changes] 
+query result object no longer implements a mapping interface. 
+To access query result as a mapping you should use the `_mapping` property. 
+That way you can process both SQLAlchemy Rows and databases Records from raw queries 
+with the same function without any instance checks.
+
+```python
+query = "SELECT * FROM notes WHERE id = :id"
+result = await database.fetch_one(query=query, values={"id": 1})
+result.id  # access field via attribute
+result._mapping['id']  # access field via mapping
+```
+
+[sqlalchemy-mapping-changes]: https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#rowproxy-is-no-longer-a-proxy-is-now-called-row-and-behaves-like-an-enhanced-named-tuple

--- a/morcilla/backends/aiopg.py
+++ b/morcilla/backends/aiopg.py
@@ -221,6 +221,7 @@ class AiopgConnection(ConnectionBackend):
                 compiled._result_columns,
                 compiled._ordered_columns,
                 compiled._textual_ordered_columns,
+                compiled._ad_hoc_textual,
                 compiled._loose_column_name_matching,
             )
         else:

--- a/morcilla/backends/aiopg.py
+++ b/morcilla/backends/aiopg.py
@@ -14,7 +14,12 @@ from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.ddl import DDLElement
 
 from morcilla.core import DatabaseURL
-from morcilla.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend
+from morcilla.interfaces import (
+    ConnectionBackend,
+    DatabaseBackend,
+    Record,
+    TransactionBackend,
+)
 
 logger = logging.getLogger("morcilla.backends.aiopg")
 
@@ -112,7 +117,7 @@ class AiopgConnection(ConnectionBackend):
         await self._database._pool.release(self._connection)
         self._connection = None
 
-    async def fetch_all(self, query: ClauseElement) -> typing.List[typing.Sequence]:
+    async def fetch_all(self, query: ClauseElement) -> typing.List[Record]:
         assert self._connection is not None, "Connection is not acquired"
         query_str, args, context = self._compile(query)
         cursor = await self._connection.cursor()
@@ -133,7 +138,7 @@ class AiopgConnection(ConnectionBackend):
         finally:
             cursor.close()
 
-    async def fetch_one(self, query: ClauseElement) -> typing.Optional[typing.Sequence]:
+    async def fetch_one(self, query: ClauseElement) -> typing.Optional[Record]:
         assert self._connection is not None, "Connection is not acquired"
         query_str, args, context = self._compile(query)
         cursor = await self._connection.cursor()

--- a/morcilla/backends/asyncmy.py
+++ b/morcilla/backends/asyncmy.py
@@ -211,6 +211,7 @@ class AsyncMyConnection(ConnectionBackend):
                 compiled._result_columns,
                 compiled._ordered_columns,
                 compiled._textual_ordered_columns,
+                compiled._ad_hoc_textual,
                 compiled._loose_column_name_matching,
             )
         else:

--- a/morcilla/backends/asyncmy.py
+++ b/morcilla/backends/asyncmy.py
@@ -12,7 +12,12 @@ from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.ddl import DDLElement
 
 from morcilla.core import LOG_EXTRA, DatabaseURL
-from morcilla.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend
+from morcilla.interfaces import (
+    ConnectionBackend,
+    DatabaseBackend,
+    Record,
+    TransactionBackend,
+)
 
 logger = logging.getLogger("morcilla.backends.asyncmy")
 
@@ -100,7 +105,7 @@ class AsyncMyConnection(ConnectionBackend):
         await self._database._pool.release(self._connection)
         self._connection = None
 
-    async def fetch_all(self, query: ClauseElement) -> typing.List[typing.Sequence]:
+    async def fetch_all(self, query: ClauseElement) -> typing.List[Record]:
         assert self._connection is not None, "Connection is not acquired"
         query_str, args, context = self._compile(query)
         async with self._connection.cursor() as cursor:
@@ -121,7 +126,7 @@ class AsyncMyConnection(ConnectionBackend):
             finally:
                 await cursor.close()
 
-    async def fetch_one(self, query: ClauseElement) -> typing.Optional[typing.Sequence]:
+    async def fetch_one(self, query: ClauseElement) -> typing.Optional[Record]:
         assert self._connection is not None, "Connection is not acquired"
         query_str, args, context = self._compile(query)
         async with self._connection.cursor() as cursor:

--- a/morcilla/backends/asyncpg.py
+++ b/morcilla/backends/asyncpg.py
@@ -18,7 +18,12 @@ except ImportError:
     xxhash = None
 
 from morcilla.core import DatabaseURL
-from morcilla.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend
+from morcilla.interfaces import (
+    ConnectionBackend,
+    DatabaseBackend,
+    Record,
+    TransactionBackend,
+)
 
 logger = logging.getLogger("morcilla.backends.asyncpg")
 CACHE_MISS = object()
@@ -216,12 +221,12 @@ class PostgresConnection(ConnectionBackend):
         with open(os.path.join(self._local_cache, key + ".bin"), "wb") as fout:
             pickle.dump(result, fout, protocol=-1)
 
-    async def fetch_all(self, query: ClauseElement) -> typing.List[typing.Sequence]:
+    async def fetch_all(self, query: ClauseElement) -> typing.List[Record]:
         query_str, args = self._compile(query)
         assert self._connection is not None
         return await self._connection.fetch(query_str, *args)
 
-    async def fetch_one(self, query: ClauseElement) -> typing.Optional[typing.Sequence]:
+    async def fetch_one(self, query: ClauseElement) -> typing.Optional[Record]:
         query_str, args = self._compile(query)
         assert self._connection is not None
         return await self._connection.fetchrow(query_str, *args)

--- a/morcilla/backends/asyncpg.py
+++ b/morcilla/backends/asyncpg.py
@@ -6,7 +6,7 @@ import sys
 import typing
 
 import asyncpg
-from sqlalchemy import __version__ as sqlalchemy_version, text
+from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import hstore, pypostgresql
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.sql import ClauseElement
@@ -262,10 +262,7 @@ class PostgresConnection(ConnectionBackend):
     ) -> typing.Tuple[str, typing.List[list]]:
         if isinstance(query, str):
             query = text(query)
-        if sqlalchemy_version.startswith("1.3"):
-            compile_kwargs = {}
-        else:
-            compile_kwargs = {"render_postcompile": True}
+        compile_kwargs = {"render_postcompile": True}
         compiled = query.compile(dialect=self._dialect, compile_kwargs=compile_kwargs)
         if not isinstance(query, DDLElement):
             compiled_params = (

--- a/morcilla/backends/mysql.py
+++ b/morcilla/backends/mysql.py
@@ -211,6 +211,7 @@ class MySQLConnection(ConnectionBackend):
                 compiled._result_columns,
                 compiled._ordered_columns,
                 compiled._textual_ordered_columns,
+                compiled._ad_hoc_textual,
                 compiled._loose_column_name_matching,
             )
         else:

--- a/morcilla/backends/mysql.py
+++ b/morcilla/backends/mysql.py
@@ -12,7 +12,12 @@ from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.ddl import DDLElement
 
 from morcilla.core import LOG_EXTRA, DatabaseURL
-from morcilla.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend
+from morcilla.interfaces import (
+    ConnectionBackend,
+    DatabaseBackend,
+    Record,
+    TransactionBackend,
+)
 
 logger = logging.getLogger("morcilla.backends.mysql")
 
@@ -100,7 +105,7 @@ class MySQLConnection(ConnectionBackend):
         await self._database._pool.release(self._connection)
         self._connection = None
 
-    async def fetch_all(self, query: ClauseElement) -> typing.List[typing.Sequence]:
+    async def fetch_all(self, query: ClauseElement) -> typing.List[Record]:
         assert self._connection is not None, "Connection is not acquired"
         query_str, args, context = self._compile(query)
         cursor = await self._connection.cursor()
@@ -121,7 +126,7 @@ class MySQLConnection(ConnectionBackend):
         finally:
             await cursor.close()
 
-    async def fetch_one(self, query: ClauseElement) -> typing.Optional[typing.Sequence]:
+    async def fetch_one(self, query: ClauseElement) -> typing.Optional[Record]:
         assert self._connection is not None, "Connection is not acquired"
         query_str, args, context = self._compile(query)
         cursor = await self._connection.cursor()

--- a/morcilla/backends/sqlite.py
+++ b/morcilla/backends/sqlite.py
@@ -216,6 +216,7 @@ class SQLiteConnection(ConnectionBackend):
                 compiled._result_columns,
                 compiled._ordered_columns,
                 compiled._textual_ordered_columns,
+                compiled._ad_hoc_textual,
                 compiled._loose_column_name_matching,
             ]
 

--- a/morcilla/backends/sqlite.py
+++ b/morcilla/backends/sqlite.py
@@ -13,7 +13,12 @@ from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.ddl import DDLElement
 
 from morcilla.core import LOG_EXTRA, DatabaseURL
-from morcilla.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend
+from morcilla.interfaces import (
+    ConnectionBackend,
+    DatabaseBackend,
+    Record,
+    TransactionBackend,
+)
 
 logger = logging.getLogger("morcilla.backends.sqlite")
 
@@ -86,10 +91,12 @@ class _RowSA20Compat(Row):
     backend so this compatibilty allows a dual aiosqlite/asyncpg code base.
 
     """
+
     def __getitem__(self, key: typing.Any) -> typing.Any:
         if isinstance(key, str):
             return getattr(self, key)
         return super().__getitem__(key)
+
 
 class SQLiteConnection(ConnectionBackend):
     def __init__(
@@ -109,7 +116,7 @@ class SQLiteConnection(ConnectionBackend):
         await self._pool.release(self._connection)
         self._connection = None
 
-    async def fetch_all(self, query: ClauseElement) -> typing.List[typing.Sequence]:
+    async def fetch_all(self, query: ClauseElement) -> typing.List[Record]:
         assert self._connection is not None, "Connection is not acquired"
         query_str, args, context = self._compile(query)
 
@@ -127,7 +134,7 @@ class SQLiteConnection(ConnectionBackend):
                 for row in rows
             ]
 
-    async def fetch_one(self, query: ClauseElement) -> typing.Optional[typing.Sequence]:
+    async def fetch_one(self, query: ClauseElement) -> typing.Optional[Record]:
         assert self._connection is not None, "Connection is not acquired"
         query_str, args, context = self._compile(query)
 

--- a/morcilla/core.py
+++ b/morcilla/core.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import contextvars as contextvars
 import functools
 import logging
 import typing
@@ -10,7 +11,12 @@ from sqlalchemy import text
 from sqlalchemy.sql import ClauseElement
 
 from morcilla.importer import import_from_string
-from morcilla.interfaces import ConnectionBackend, DatabaseBackend, TransactionBackend
+from morcilla.interfaces import (
+    ConnectionBackend,
+    DatabaseBackend,
+    Record,
+    TransactionBackend,
+)
 
 try:  # pragma: no cover
     import click
@@ -114,13 +120,13 @@ class Database:
 
     async def fetch_all(
         self, query: typing.Union[ClauseElement, str], values: dict = None
-    ) -> typing.List[typing.Sequence]:
+    ) -> typing.List[Record]:
         async with self.connection() as connection:
             return await connection.fetch_all(query, values)
 
     async def fetch_one(
         self, query: typing.Union[ClauseElement, str], values: dict = None
-    ) -> typing.Optional[typing.Sequence]:
+    ) -> typing.Optional[Record]:
         async with self.connection() as connection:
             return await connection.fetch_one(query, values)
 
@@ -199,14 +205,14 @@ class Connection:
 
     async def fetch_all(
         self, query: typing.Union[ClauseElement, str], values: dict = None
-    ) -> typing.List[typing.Sequence]:
+    ) -> typing.List[Record]:
         built_query = self._build_query(query, values)
         async with self._query_lock:
             return await self._connection.fetch_all(built_query)
 
     async def fetch_one(
         self, query: typing.Union[ClauseElement, str], values: dict = None
-    ) -> typing.Optional[typing.Sequence]:
+    ) -> typing.Optional[Record]:
         built_query = self._build_query(query, values)
         async with self._query_lock:
             return await self._connection.fetch_one(built_query)

--- a/morcilla/core.py
+++ b/morcilla/core.py
@@ -290,6 +290,9 @@ class Connection:
         return query
 
 
+_CallableType = typing.TypeVar("_CallableType", bound=typing.Callable)
+
+
 class Transaction:
     def __init__(
         self,
@@ -322,13 +325,13 @@ class Transaction:
         else:
             await self.commit()
 
-    def __await__(self) -> typing.Generator:
+    def __await__(self) -> typing.Generator[None, None, "Transaction"]:
         """
         Called if using the low-level `transaction = await database.transaction()`
         """
         return self.start().__await__()
 
-    def __call__(self, func: typing.Callable) -> typing.Callable:
+    def __call__(self, func: _CallableType) -> _CallableType:
         """
         Called if using `@database.transaction()` as a decorator.
         """
@@ -338,7 +341,7 @@ class Transaction:
             async with self:
                 return await func(*args, **kwargs)
 
-        return wrapper
+        return wrapper  # type: ignore
 
     async def start(self) -> "Transaction":
         self._transaction = (

--- a/morcilla/core.py
+++ b/morcilla/core.py
@@ -112,20 +112,24 @@ class Database:
 
     async def __aexit__(
         self,
-        exc_type: typing.Type[BaseException] = None,
-        exc_value: BaseException = None,
-        traceback: TracebackType = None,
+        exc_type: typing.Optional[typing.Type[BaseException]] = None,
+        exc_value: typing.Optional[BaseException] = None,
+        traceback: typing.Optional[TracebackType] = None,
     ) -> None:
         await self.disconnect()
 
     async def fetch_all(
-        self, query: typing.Union[ClauseElement, str], values: dict = None
+        self,
+        query: typing.Union[ClauseElement, str],
+        values: typing.Optional[dict] = None,
     ) -> typing.List[Record]:
         async with self.connection() as connection:
             return await connection.fetch_all(query, values)
 
     async def fetch_one(
-        self, query: typing.Union[ClauseElement, str], values: dict = None
+        self,
+        query: typing.Union[ClauseElement, str],
+        values: typing.Optional[dict] = None,
     ) -> typing.Optional[Record]:
         async with self.connection() as connection:
             return await connection.fetch_one(query, values)
@@ -133,14 +137,16 @@ class Database:
     async def fetch_val(
         self,
         query: typing.Union[ClauseElement, str],
-        values: dict = None,
+        values: typing.Optional[dict] = None,
         column: typing.Any = 0,
     ) -> typing.Any:
         async with self.connection() as connection:
             return await connection.fetch_val(query, values, column=column)
 
     async def execute(
-        self, query: typing.Union[ClauseElement, str], values: dict = None
+        self,
+        query: typing.Union[ClauseElement, str],
+        values: typing.Optional[dict] = None,
     ) -> typing.Any:
         async with self.connection() as connection:
             return await connection.execute(query, values)
@@ -152,7 +158,9 @@ class Database:
             return await connection.execute_many(query, values)
 
     async def iterate(
-        self, query: typing.Union[ClauseElement, str], values: dict = None
+        self,
+        query: typing.Union[ClauseElement, str],
+        values: typing.Optional[dict] = None,
     ) -> typing.AsyncGenerator[typing.Mapping, None]:
         async with self.connection() as connection:
             async for record in connection.iterate(query, values):
@@ -193,9 +201,9 @@ class Connection:
 
     async def __aexit__(
         self,
-        exc_type: typing.Type[BaseException] = None,
-        exc_value: BaseException = None,
-        traceback: TracebackType = None,
+        exc_type: typing.Optional[typing.Type[BaseException]] = None,
+        exc_value: typing.Optional[BaseException] = None,
+        traceback: typing.Optional[TracebackType] = None,
     ) -> None:
         async with self._connection_lock:
             assert self._connection is not None
@@ -204,14 +212,18 @@ class Connection:
                 await self._connection.release()
 
     async def fetch_all(
-        self, query: typing.Union[ClauseElement, str], values: dict = None
+        self,
+        query: typing.Union[ClauseElement, str],
+        values: typing.Optional[dict] = None,
     ) -> typing.List[Record]:
         built_query = self._build_query(query, values)
         async with self._query_lock:
             return await self._connection.fetch_all(built_query)
 
     async def fetch_one(
-        self, query: typing.Union[ClauseElement, str], values: dict = None
+        self,
+        query: typing.Union[ClauseElement, str],
+        values: typing.Optional[dict] = None,
     ) -> typing.Optional[Record]:
         built_query = self._build_query(query, values)
         async with self._query_lock:
@@ -220,7 +232,7 @@ class Connection:
     async def fetch_val(
         self,
         query: typing.Union[ClauseElement, str],
-        values: dict = None,
+        values: typing.Optional[dict] = None,
         column: typing.Any = 0,
     ) -> typing.Any:
         built_query = self._build_query(query, values)
@@ -228,7 +240,9 @@ class Connection:
             return await self._connection.fetch_val(built_query, column)
 
     async def execute(
-        self, query: typing.Union[ClauseElement, str], values: dict = None
+        self,
+        query: typing.Union[ClauseElement, str],
+        values: typing.Optional[dict] = None,
     ) -> typing.Any:
         built_query = self._build_query(query, values)
         async with self._query_lock:
@@ -247,7 +261,9 @@ class Connection:
                 return await self._connection.execute_many(queries)
 
     async def iterate(
-        self, query: typing.Union[ClauseElement, str], values: dict = None
+        self,
+        query: typing.Union[ClauseElement, str],
+        values: typing.Optional[dict] = None,
     ) -> typing.AsyncGenerator[typing.Any, None]:
         built_query = self._build_query(query, values)
         async with self.transaction():
@@ -278,7 +294,7 @@ class Connection:
 
     @staticmethod
     def _build_query(
-        query: typing.Union[ClauseElement, str], values: dict = None
+        query: typing.Union[ClauseElement, str], values: typing.Optional[dict] = None
     ) -> ClauseElement:
         if isinstance(query, str):
             query = text(query)
@@ -313,9 +329,9 @@ class Transaction:
 
     async def __aexit__(
         self,
-        exc_type: typing.Type[BaseException] = None,
-        exc_value: BaseException = None,
-        traceback: TracebackType = None,
+        exc_type: typing.Optional[typing.Type[BaseException]] = None,
+        exc_value: typing.Optional[BaseException] = None,
+        traceback: typing.Optional[TracebackType] = None,
     ) -> None:
         """
         Called when exiting `async with database.transaction()`

--- a/morcilla/interfaces.py
+++ b/morcilla/interfaces.py
@@ -1,4 +1,5 @@
 import typing
+from collections.abc import Sequence
 
 from sqlalchemy.sql import ClauseElement
 
@@ -21,10 +22,10 @@ class ConnectionBackend:
     async def release(self) -> None:
         raise NotImplementedError()  # pragma: no cover
 
-    async def fetch_all(self, query: ClauseElement) -> typing.List[typing.Sequence]:
+    async def fetch_all(self, query: ClauseElement) -> typing.List["Record"]:
         raise NotImplementedError()  # pragma: no cover
 
-    async def fetch_one(self, query: ClauseElement) -> typing.Optional[typing.Sequence]:
+    async def fetch_one(self, query: ClauseElement) -> typing.Optional["Record"]:
         raise NotImplementedError()  # pragma: no cover
 
     async def fetch_val(
@@ -72,4 +73,10 @@ class TransactionBackend:
         raise NotImplementedError()  # pragma: no cover
 
     async def rollback(self) -> None:
+        raise NotImplementedError()  # pragma: no cover
+
+
+class Record(Sequence):
+    @property
+    def _mapping(self) -> typing.Mapping:
         raise NotImplementedError()  # pragma: no cover

--- a/morcilla/interfaces.py
+++ b/morcilla/interfaces.py
@@ -80,3 +80,6 @@ class Record(Sequence):
     @property
     def _mapping(self) -> typing.Mapping:
         raise NotImplementedError()  # pragma: no cover
+
+    def __getitem__(self, key: typing.Any) -> typing.Any:
+        raise NotImplementedError()  # pragma: no cover

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ current_version = 0.5.33
 [mypy]
 disallow_untyped_defs = True
 ignore_missing_imports = True
+no_implicit_optional = True
 
 [tool:isort]
 profile = black

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     author_email="tom@tomchristie.com",
     packages=get_packages("morcilla"),
     package_data={"morcilla": ["py.typed"]},
-    install_requires=["sqlalchemy>=1.4,<1.4.42"],
+    install_requires=["sqlalchemy>=1.4.42,<1.5"],
     extras_require={
         "postgresql": ["asyncpg-rkt"],
         "mysql": ["aiomysql"],

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     author_email="tom@tomchristie.com",
     packages=get_packages("morcilla"),
     package_data={"morcilla": ["py.typed"]},
-    install_requires=["sqlalchemy>=1.3,<1.4.42"],
+    install_requires=["sqlalchemy>=1.4,<1.4.42"],
     extras_require={
         "postgresql": ["asyncpg-rkt"],
         "mysql": ["aiomysql"],

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1137,9 +1137,16 @@ async def test_mapping_property_interface(database_url):
 
         query = notes.select()
         single_result = await database.fetch_one(query=query)
-        assert single_result._mapping["text"] == "example1"
-        assert single_result._mapping["completed"] is True
+
+        def _get_mapping(result):
+            # asyncpg record does not support _mapping
+            if ".asyncpg." in str(type(database._backend)):
+                return result
+            return result._mapping
+
+        assert _get_mapping(single_result)["text"] == "example1"
+        assert _get_mapping(single_result)["completed"] is True
 
         list_result = await database.fetch_all(query=query)
-        assert list_result[0]._mapping["text"] == "example1"
-        assert list_result[0]._mapping["completed"] is True
+        assert _get_mapping(list_result[0])["text"] == "example1"
+        assert _get_mapping(list_result[0])["completed"] is True

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1105,3 +1105,41 @@ async def test_postcompile_queries(database_url):
         results = await database.fetch_all(query=query)
 
         assert len(results) == 0
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@mysql_versions
+@async_adapter
+async def test_result_named_access(database_url):
+    async with Database(database_url) as database:
+        query = notes.insert()
+        values = {"text": "example1", "completed": True}
+        await database.execute(query, values)
+
+        query = notes.select().where(notes.c.text == "example1")
+        result = await database.fetch_one(query=query)
+
+        assert result.text == "example1"
+        assert result.completed is True
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@mysql_versions
+@async_adapter
+async def test_mapping_property_interface(database_url):
+    """
+    Test that all connections implement interface with `_mapping` property
+    """
+    async with Database(database_url) as database:
+        query = notes.insert()
+        values = {"text": "example1", "completed": True}
+        await database.execute(query, values)
+
+        query = notes.select()
+        single_result = await database.fetch_one(query=query)
+        assert single_result._mapping["text"] == "example1"
+        assert single_result._mapping["completed"] is True
+
+        list_result = await database.fetch_all(query=query)
+        assert list_result[0]._mapping["text"] == "example1"
+        assert list_result[0]._mapping["completed"] is True


### PR DESCRIPTION
Two change, needed for SQLAlchemy 1.4.42 and maybe sufficient for 2:
- add getitem interface to Row returned by sqlite, so we  can use asyncpg Record and Row with same getitem interface
  (SQLAlchemy 2 only has getattr)
- add `_ad_hoc_textual` to execution context